### PR TITLE
Typo capital letter

### DIFF
--- a/tex_files/tandem.tex
+++ b/tex_files/tandem.tex
@@ -9,7 +9,7 @@
 \Opensolutionfile{ans}
 
 
-Consider two $M/M/1$ stations in tandem. Suppose we can remove the variability in the service processing times at one, but not both, of the servers. which one is the better one to spend it on, in terms of reducing waiting times?  After we obtained some insights into this question, we will provide a model to approximate the waiting time in a tandem  of $G/G/1$ queues.
+Consider two $M/M/1$ stations in tandem. Suppose we can remove the variability in the service processing times at one, but not both, of the servers. Which one is the better one to spend it on, in terms of reducing waiting times?  After we obtained some insights into this question, we will provide a model to approximate the waiting time in a tandem  of $G/G/1$ queues.
 
 \begin{exercise}
 Assuming that jobs arrive at the first station at rate $\lambda$, and are served at rate $\mu_i$ at station $i$, show that the average queueing time for the tandem of two $M/M/1$ queues is given by


### PR DESCRIPTION
"but not both, of the servers. which one is the better one to spend it on, in terms of reducing waiting times?" This is in the first paragraph of the section. The word "which" has to be with a capital letter (W).