### PR TITLE
"at which event occur" is wrong grammar

### DIFF
--- a/tex_files/poissondistribution.tex
+++ b/tex_files/poissondistribution.tex
@@ -90,7 +90,7 @@ $\lambda$, and write $N(t)\sim P(\lambda t)$.
   that $n p=\lambda t$. 
   \begin{hint}
 First find $p$, $n$, $\lambda$ and $t$ such that the rate
-    at which event occur in both processes are the same. Then consider
+    at which an event occurs in both processes are the same. Then consider
     the binomial distribution and use the standard limit
     $(1-x/n)^n \to e^{-x}$ as $n\to \infty$. 
   \end{hint}


### PR DESCRIPTION
Write "at which an event occurs" or "at which events occur" instead to fix this mistake